### PR TITLE
Fix GitHub actions cacheing

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -15,7 +15,9 @@ jobs:
           path: ${{env.INSTALL_CACHE_PATH}}
           key: ${{ runner.os }}-build-${{env.INSTALL_CACHE_NAME}}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: ${{ runner.os }}-build-${{env.INSTALL_CACHE_NAME}}-
-      - run: npm install
+      - name: Install Dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: npm install
   lint:
     needs: install
     runs-on: ubuntu-latest

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -10,6 +10,7 @@ jobs:
         with:
           env-file: .env
       - name: Cache node modules
+        id: cache
         uses: actions/cache@v2
         with:
           path: ${{env.INSTALL_CACHE_PATH}}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -7,14 +7,21 @@ jobs:
   codecov:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Check out repository
         uses: actions/checkout@v2
-      - name: Setup
-        uses: actions/setup-node@v1
+      - uses: c-py/action-dotenv-to-setenv@v1
         with:
-          node-version: 12
-      - name: Install
-        run: npm ci
+          env-file: .env
+      - name: Cache node modules
+        id: cache
+        uses: actions/cache@v2
+        with:
+          path: ${{env.INSTALL_CACHE_PATH}}
+          key: ${{ runner.os }}-build-${{env.INSTALL_CACHE_NAME}}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: ${{ runner.os }}-build-${{env.INSTALL_CACHE_NAME}}-
+      - name: Install Dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: npm install
       - name: Testing
         run: npm run test:unit
       - name: Sending to Codecov

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ $ npm install --save vue-ld
 Main.js
 
 ```javascript
-import Vue from 'vue'
+import Vue from 'vue';
 import { VueLd } from 'vue-ld';
 
 Vue.use(VueLd, {
@@ -28,7 +28,8 @@ Vue.use(VueLd, {
   },
   options: {
     // Standard LaunchDarkly JavaScript SDK options
-  }
+  },
+});
 ```
 
 #### Additional Plugin Options


### PR DESCRIPTION
[Story](https://app.clubhouse.io/dashhudson/story/31415/fix-github-actions-cacheing)

Applying some learnings from helping with cypress dependency cacheing. 

Caching is initially scoped to the current branch; if no hits are found it checks upstream. This means the push action should cache something. 

Install step down to 16s with no dependency changes.