### PR TITLE
Stub LaunchDarkly in cypress environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,10 @@ Vue.use(VueLd, {
 
 #### Additional Plugin Options
 
-| key                   | description                                                                        | default | type      |
-| :-------------------- | ---------------------------------------------------------------------------------- | ------- | --------- |
-| `readyBeforeIdentify` | If set to false, the `$ld.ready` will only be true after identify has been called. | `true`  | `Boolean` |
+| key                   | description                                                                                                                            | default     | type               |
+| :-------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | ----------- | ------------------ |
+| `readyBeforeIdentify` | If set to false, the `$ld.ready` will only be true after identify has been called.                                                     | `true`      | `Boolean`          |
+| `flagsStub`           | If provided, the ldClient will not be initialized the and `$ld.flags` will set to the provided stub; this can be helpful in e2e tests. | `undefined` | `Object` / `Proxy` |
 
 ### Template
 
@@ -95,12 +96,11 @@ export default {
 
 #### Arguments
 
-| key            | description                                                                                    | type                               |
-| :------------- | ---------------------------------------------------------------------------------------------- | ---------------------------------- |
-| `requiredFlag` | If the given feature flag is false, the user will be redirected to the given route.            | `string`                           |
-| `to`           | The path which vue router will push. Functions passed are expected to resolve to a valid path. | `string`, `object`, or `function`  |
-| `invertFlag`   | If set to true the the inverse of the requiredFlag's value will be used.                       | `boolean`                          |
-
+| key            | description                                                                                    | type                              |
+| :------------- | ---------------------------------------------------------------------------------------------- | --------------------------------- |
+| `requiredFlag` | If the given feature flag is false, the user will be redirected to the given route.            | `string`                          |
+| `to`           | The path which vue router will push. Functions passed are expected to resolve to a valid path. | `string`, `object`, or `function` |
+| `invertFlag`   | If set to true the the inverse of the requiredFlag's value will be used.                       | `boolean`                         |
 
 ### LDRouteGuard Component
 
@@ -123,12 +123,12 @@ const route = {
 
 #### Props
 
-| key            | description                                                                                    | type                               |
-| :------------- | ---------------------------------------------------------------------------------------------- | ---------------------------------- |
-| `component`    | The component to be rendered given the required feature flag is true.                          | `vue component`                    |
-| `requiredFlag` | If the given feature flag is false, the user will be redirected to the given route.            | `string`                           |
-| `to`           | The path which vue router will push. Functions passed are expected to resolve to a valid path. | `string`, `object`, or `function`  |
-| `invertFlag`   | If set to true the the inverse of the requiredFlag's value will be used.                       | `boolean`                          |
+| key            | description                                                                                    | type                              |
+| :------------- | ---------------------------------------------------------------------------------------------- | --------------------------------- |
+| `component`    | The component to be rendered given the required feature flag is true.                          | `vue component`                   |
+| `requiredFlag` | If the given feature flag is false, the user will be redirected to the given route.            | `string`                          |
+| `to`           | The path which vue router will push. Functions passed are expected to resolve to a valid path. | `string`, `object`, or `function` |
+| `invertFlag`   | If set to true the the inverse of the requiredFlag's value will be used.                       | `boolean`                         |
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ Vue.use(VueLd, {
 
 #### Additional Plugin Options
 
-| key                   | description                                                                                                                            | default     | type               |
-| :-------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | ----------- | ------------------ |
-| `readyBeforeIdentify` | If set to false, the `$ld.ready` will only be true after identify has been called.                                                     | `true`      | `Boolean`          |
-| `flagsStub`           | If provided, the ldClient will not be initialized the and `$ld.flags` will set to the provided stub; this can be helpful in e2e tests. | `undefined` | `Object` / `Proxy` |
+| key                   | description                                                                                                                        | default     | type               |
+| :-------------------- | ---------------------------------------------------------------------------------------------------------------------------------- | ----------- | ------------------ |
+| `readyBeforeIdentify` | If set to false, the `$ld.ready` will only be true after identify has been called.                                                 | `true`      | `Boolean`          |
+| `flagsStub`           | If provided, the ldClient will not be initialized and `$ld.flags` will set to the provided stub; this can be helpful in e2e tests. | `undefined` | `Object` / `Proxy` |
 
 ### Template
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-ld",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "A Vue.js wrapper for the LaunchDarkly SDK for Browser JavaScript",
   "main": "dist/index.cjs.js",
   "module": "dist/index.es.js",

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,3 @@
-export { default as VueLd } from './plugin';
+export { default as VueLd, initialize } from './plugin';
 export { default as ldRedirectMixin } from './mixins/ldRedirect';
 export { default as LDRouteGuard } from './components/LDRouteGuard.vue';

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,46 +1,72 @@
 import * as LDClient from 'launchdarkly-js-client-sdk';
 import { formatFlags } from './utils';
 
-export default {
-  install(Vue, options) {
-    const { clientSideId, user, options: ldOptions, readyBeforeIdentify = true } = options;
-
-    const ldClient = LDClient.initialize(clientSideId, user, ldOptions);
-
-    const $ld = Vue.observable({
-      ldClient,
-      identify({ newUser, hash, callback }, vueLdCallback) {
-        return new Promise((r) => {
-          this.ready = false;
-          ldClient.identify(newUser, hash, callback).then(() => {
-            this.ready = true;
-            if (vueLdCallback) {
-              const boundVueLdCallback = vueLdCallback.bind($ld);
-              boundVueLdCallback();
-            }
-            r();
-          });
+export const initialize = ({ clientSideId, user, ldOptions, readyBeforeIdentify }) => {
+  const ldClient = LDClient.initialize(clientSideId, user, ldOptions);
+  const $ld = {
+    ldClient,
+    identify({ newUser, hash, callback }, vueLdCallback) {
+      return new Promise((r) => {
+        this.ready = false;
+        ldClient.identify(newUser, hash, callback).then(() => {
+          this.ready = true;
+          if (vueLdCallback) {
+            const boundVueLdCallback = vueLdCallback.bind($ld);
+            boundVueLdCallback();
+          }
+          r();
         });
-      },
-      flags: {},
-      ready: false,
-    });
+      });
+    },
+    flags: {},
+    ready: false,
+  };
 
-    ldClient.on('ready', () => {
-      $ld.flags = formatFlags(ldClient.allFlags());
-      $ld.ready = readyBeforeIdentify;
-    });
+  ldClient.on('ready', () => {
+    $ld.flags = formatFlags(ldClient.allFlags());
+    $ld.ready = readyBeforeIdentify;
+  });
 
-    ldClient.on('change', (changes) => {
-      const flattenedFlags = Object.fromEntries(
-        Object.keys(changes).map((key) => [key, changes[key].current])
-      );
-      $ld.flags = {
-        ...$ld.flags,
-        ...formatFlags(flattenedFlags),
-      };
-    });
+  ldClient.on('change', (changes) => {
+    const flattenedFlags = Object.fromEntries(
+      Object.keys(changes).map((key) => [key, changes[key].current])
+    );
+    $ld.flags = {
+      ...$ld.flags,
+      ...formatFlags(flattenedFlags),
+    };
+  });
+  return $ld;
+};
+
+const stub = ({ flagsStub, readyBeforeIdentify }) => {
+  return {
+    identify() {
+      this.ready = true;
+    },
+    flags: flagsStub,
+    ready: readyBeforeIdentify,
+  };
+};
+
+export default {
+  async install(Vue, options) {
+    const {
+      clientSideId,
+      user,
+      options: ldOptions,
+      flagsStub,
+      readyBeforeIdentify = true,
+    } = options;
+
+    let $ld;
+
+    if (flagsStub) {
+      $ld = stub({ flagsStub, readyBeforeIdentify });
+    } else {
+      $ld = initialize({ clientSideId, user, ldOptions, readyBeforeIdentify });
+    }
     // eslint-disable-next-line no-param-reassign
-    Vue.prototype.$ld = $ld;
+    Vue.prototype.$ld = Vue.observable($ld);
   },
 };

--- a/tests/unit/vue-ld.spec.js
+++ b/tests/unit/vue-ld.spec.js
@@ -95,4 +95,27 @@ describe('VueLd Plugin', () => {
     expect(vueLdCallback).toBeCalled();
     expect(vueLdCallback.mock.instances[0]).toBe(wrapper.vm.$ld);
   });
+
+  it('stubs flags when passed the option', async () => {
+    localVue.use(VueLd, {
+      ...vueLdOptions,
+      flagsStub: new Proxy(
+        {
+          never: false,
+        },
+        {
+          get(obj, prop) {
+            const value = obj[prop];
+            return value === undefined ? true : value;
+          },
+        }
+      ),
+    });
+    wrapper = mount(Component, {
+      localVue,
+    });
+
+    expect(wrapper.vm.$ld.flags.never).toBe(false);
+    expect(wrapper.vm.$ld.flags.anythingElse).toBe(true);
+  });
 });

--- a/tests/unit/vue-ld.spec.js
+++ b/tests/unit/vue-ld.spec.js
@@ -99,6 +99,10 @@ describe('VueLd Plugin', () => {
   it('stubs flags when passed the option', async () => {
     localVue.use(VueLd, {
       ...vueLdOptions,
+      /*
+        Using a proxy like this will allow you to return true for everything
+        not explicitly not on the base object or set later.
+      */
       flagsStub: new Proxy(
         {
           never: false,
@@ -116,6 +120,12 @@ describe('VueLd Plugin', () => {
     });
 
     expect(wrapper.vm.$ld.flags.never).toBe(false);
+    expect(wrapper.vm.$ld.flags.anythingElse).toBe(true);
+
+    wrapper.vm.$ld.flags.neverLater = false;
+    expect(wrapper.vm.$ld.flags.neverLater).toBe(false);
+
+    delete wrapper.vm.$ld.flags.neverLater;
     expect(wrapper.vm.$ld.flags.anythingElse).toBe(true);
   });
 });

--- a/tests/unit/vue-ld.spec.js
+++ b/tests/unit/vue-ld.spec.js
@@ -101,7 +101,7 @@ describe('VueLd Plugin', () => {
       ...vueLdOptions,
       /*
         Using a proxy like this will allow you to return true for everything
-        not explicitly not on the base object or set later.
+        not explicitly on the base object or set later.
       */
       flagsStub: new Proxy(
         {


### PR DESCRIPTION
Story details: https://app.clubhouse.io/dashhudson/story/42393

## flagsStub
This is intended to use in e2e tests where users are created dynamically; stubbing it with a proxy will allow for most tests. 

## Export Initialize
If you want to whitelist certain users after stubbing, you can initialize vue-ld manually whenever it makes sense in your product.