### PR TITLE
Enable graceful failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-ld",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "A Vue.js wrapper for the LaunchDarkly SDK for Browser JavaScript",
   "main": "dist/index.cjs.js",
   "module": "dist/index.es.js",

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -20,12 +20,17 @@ export const initialize = ({ clientSideId, user, ldOptions, readyBeforeIdentify 
     },
     flags: {},
     ready: false,
+    error: null,
   };
 
   ldClient.on('ready', () => {
     $ld.flags = formatFlags(ldClient.allFlags());
     $ld.ready = readyBeforeIdentify;
   });
+  // .catch((e) => {
+  //   $ld.error = e;
+  //   throw e;
+  // });
 
   ldClient.on('change', (changes) => {
     const flattenedFlags = Object.fromEntries(
@@ -36,6 +41,12 @@ export const initialize = ({ clientSideId, user, ldOptions, readyBeforeIdentify 
       ...formatFlags(flattenedFlags),
     };
   });
+
+  ldClient.on('error', (e) => {
+    $ld.error = e;
+    throw e;
+  });
+
   return $ld;
 };
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,5 +1,5 @@
 import * as LDClient from 'launchdarkly-js-client-sdk';
-import { formatFlags } from './utils';
+import { formatFlags, rethrow } from './utils';
 
 export const initialize = ({ clientSideId, user, ldOptions, readyBeforeIdentify }) => {
   const ldClient = LDClient.initialize(clientSideId, user, ldOptions);
@@ -40,7 +40,7 @@ export const initialize = ({ clientSideId, user, ldOptions, readyBeforeIdentify 
 
   ldClient.on('error', (e) => {
     $ld.error = e;
-    throw e;
+    rethrow(e);
   });
 
   return $ld;

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -27,10 +27,6 @@ export const initialize = ({ clientSideId, user, ldOptions, readyBeforeIdentify 
     $ld.flags = formatFlags(ldClient.allFlags());
     $ld.ready = readyBeforeIdentify;
   });
-  // .catch((e) => {
-  //   $ld.error = e;
-  //   throw e;
-  // });
 
   ldClient.on('change', (changes) => {
     const flattenedFlags = Object.fromEntries(

--- a/src/utils.js
+++ b/src/utils.js
@@ -7,3 +7,8 @@ export const formatFlags = (flags) => {
     })
   );
 };
+
+export const rethrow = (e) => {
+  // Intended to be mocked in tests to avoid uncaught promise rejections in dependencies
+  throw e;
+};

--- a/tests/unit/vue-ld.spec.js
+++ b/tests/unit/vue-ld.spec.js
@@ -13,16 +13,11 @@ describe('VueLd Plugin', () => {
   let localVue;
   let server;
   let warnSpy;
+  let wrapper;
+
   beforeEach(() => {
     localVue = createLocalVue();
     server = sinon.createFakeServer();
-    server.autoRespond = true;
-    server.autoRespondAfter = 0;
-    server.respondWith([
-      200,
-      { 'Content-Type': 'application/json' },
-      JSON.stringify(flagsResponse),
-    ]);
     warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
     errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
   });
@@ -33,99 +28,130 @@ describe('VueLd Plugin', () => {
     errorSpy.mockRestore();
   });
 
-  let wrapper;
-  it('changes ready state before identify', async () => {
-    localVue.use(VueLd, vueLdOptions);
-    wrapper = mount(Component, {
-      localVue,
+  describe('Success states', () => {
+    beforeEach(() => {
+      server.autoRespond = true;
+      server.autoRespondAfter = 0;
+      server.respondWith([
+        200,
+        { 'Content-Type': 'application/json' },
+        JSON.stringify(flagsResponse),
+      ]);
     });
-    expect(wrapper.vm.$ld).not.toBe(undefined);
-    expect(wrapper.vm.$ld.ready).toBe(false);
+    it('changes ready state before identify', async () => {
+      localVue.use(VueLd, vueLdOptions);
+      wrapper = mount(Component, {
+        localVue,
+      });
+      expect(wrapper.vm.$ld).not.toBe(undefined);
+      expect(wrapper.vm.$ld.ready).toBe(false);
 
-    await ldClientReady(wrapper);
+      await ldClientReady(wrapper);
 
-    expect(wrapper.vm.$ld.ready).toBe(true);
-  });
-
-  it('changes ready state after identify', async () => {
-    localVue.use(VueLd, {
-      ...vueLdOptions,
-      readyBeforeIdentify: false,
-    });
-    wrapper = mount(Component, {
-      localVue,
+      expect(wrapper.vm.$ld.ready).toBe(true);
     });
 
-    expect(wrapper.vm.$ld).not.toBe(undefined);
-    expect(wrapper.vm.$ld.ready).toBe(false);
+    it('changes ready state after identify', async () => {
+      localVue.use(VueLd, {
+        ...vueLdOptions,
+        readyBeforeIdentify: false,
+      });
+      wrapper = mount(Component, {
+        localVue,
+      });
 
-    await ldClientReady(wrapper);
-    expect(wrapper.vm.$ld.ready).toBe(false);
-    await wrapper.vm.$ld.identify({
-      newUser: {
-        key: 'anonymous2',
-        email: 'anonymous2@test.com',
-        name: 'Anonymous User 2',
-      },
-    });
-    expect(wrapper.vm.$ld.ready).toBe(true);
-  });
+      expect(wrapper.vm.$ld).not.toBe(undefined);
+      expect(wrapper.vm.$ld.ready).toBe(false);
 
-  it('calls vueLdCallback after ready with correct context', async () => {
-    localVue.use(VueLd, {
-      ...vueLdOptions,
-      readyBeforeIdentify: false,
-    });
-    wrapper = mount(Component, {
-      localVue,
-    });
-    const vueLdCallback = jest.fn();
-    await ldClientReady(wrapper);
-    await wrapper.vm.$ld.identify(
-      {
+      await ldClientReady(wrapper);
+      expect(wrapper.vm.$ld.ready).toBe(false);
+      await wrapper.vm.$ld.identify({
         newUser: {
           key: 'anonymous2',
           email: 'anonymous2@test.com',
           name: 'Anonymous User 2',
         },
-      },
-      vueLdCallback
-    );
+      });
+      expect(wrapper.vm.$ld.ready).toBe(true);
+    });
 
-    expect(vueLdCallback).toBeCalled();
-    expect(vueLdCallback.mock.instances[0]).toBe(wrapper.vm.$ld);
+    it('calls vueLdCallback after ready with correct context', async () => {
+      localVue.use(VueLd, {
+        ...vueLdOptions,
+        readyBeforeIdentify: false,
+      });
+      wrapper = mount(Component, {
+        localVue,
+      });
+      const vueLdCallback = jest.fn();
+      await ldClientReady(wrapper);
+      await wrapper.vm.$ld.identify(
+        {
+          newUser: {
+            key: 'anonymous2',
+            email: 'anonymous2@test.com',
+            name: 'Anonymous User 2',
+          },
+        },
+        vueLdCallback
+      );
+
+      expect(vueLdCallback).toBeCalled();
+      expect(vueLdCallback.mock.instances[0]).toBe(wrapper.vm.$ld);
+    });
+
+    it('stubs flags when passed the option', async () => {
+      localVue.use(VueLd, {
+        ...vueLdOptions,
+        /*
+          Using a proxy like this will allow you to return true for everything
+          not explicitly on the base object or set later.
+        */
+        flagsStub: new Proxy(
+          {
+            never: false,
+          },
+          {
+            get(obj, prop) {
+              const value = obj[prop];
+              return value === undefined ? true : value;
+            },
+          }
+        ),
+      });
+      wrapper = mount(Component, {
+        localVue,
+      });
+
+      expect(wrapper.vm.$ld.flags.never).toBe(false);
+      expect(wrapper.vm.$ld.flags.anythingElse).toBe(true);
+
+      wrapper.vm.$ld.flags.neverLater = false;
+      expect(wrapper.vm.$ld.flags.neverLater).toBe(false);
+
+      delete wrapper.vm.$ld.flags.neverLater;
+      expect(wrapper.vm.$ld.flags.anythingElse).toBe(true);
+    });
   });
 
-  it('stubs flags when passed the option', async () => {
-    localVue.use(VueLd, {
-      ...vueLdOptions,
-      /*
-        Using a proxy like this will allow you to return true for everything
-        not explicitly on the base object or set later.
-      */
-      flagsStub: new Proxy(
-        {
-          never: false,
-        },
-        {
-          get(obj, prop) {
-            const value = obj[prop];
-            return value === undefined ? true : value;
-          },
-        }
-      ),
-    });
-    wrapper = mount(Component, {
-      localVue,
+  describe('Error states', () => {
+    beforeEach(() => {
+      server.autoRespond = true;
+      server.autoRespondAfter = 0;
+      server.respondWith([
+        400,
+        { 'Content-Type': 'application/json' },
+        JSON.stringify({ message: 'Bad Request' }),
+      ]);
     });
 
-    expect(wrapper.vm.$ld.flags.never).toBe(false);
-    expect(wrapper.vm.$ld.flags.anythingElse).toBe(true);
-
-    wrapper.vm.$ld.flags.neverLater = false;
-    expect(wrapper.vm.$ld.flags.neverLater).toBe(false);
-
-    delete wrapper.vm.$ld.flags.neverLater;
-    expect(wrapper.vm.$ld.flags.anythingElse).toBe(true);
+    it.only('should set error when ldClient emits an error', async () => {
+      localVue.use(VueLd, vueLdOptions);
+      wrapper = mount(Component, {
+        localVue,
+      });
+      await ldClientReady(wrapper);
+      expect(wrapper.vm.$ld.error).toBeTruthy(undefined);
+    });
   });
 });

--- a/tests/unit/vue-ld.spec.js
+++ b/tests/unit/vue-ld.spec.js
@@ -1,12 +1,20 @@
 import sinon from 'sinon';
 import { createLocalVue, mount } from '@vue/test-utils';
 import VueLd from '@/plugin';
+import { rethrow } from '@/utils';
 import { ldClientReady } from './utils';
 import { vueLdOptions, flagsResponse } from './dummy';
 
 const Component = {
   template: '<div></div>',
 };
+
+jest.mock('@/utils', () => {
+  return {
+    ...jest.requireActual('@/utils'),
+    rethrow: jest.fn(),
+  };
+});
 
 describe('VueLd Plugin', () => {
   let errorSpy;
@@ -145,13 +153,15 @@ describe('VueLd Plugin', () => {
       ]);
     });
 
-    it.only('should set error when ldClient emits an error', async () => {
+    it('should set error when ldClient emits an error', async () => {
       localVue.use(VueLd, vueLdOptions);
       wrapper = mount(Component, {
         localVue,
       });
       await ldClientReady(wrapper);
       expect(wrapper.vm.$ld.error).toBeTruthy();
+      // Should not eat errors
+      expect(rethrow).toHaveBeenCalled();
     });
   });
 });

--- a/tests/unit/vue-ld.spec.js
+++ b/tests/unit/vue-ld.spec.js
@@ -151,7 +151,7 @@ describe('VueLd Plugin', () => {
         localVue,
       });
       await ldClientReady(wrapper);
-      expect(wrapper.vm.$ld.error).toBeTruthy(undefined);
+      expect(wrapper.vm.$ld.error).toBeTruthy();
     });
   });
 });


### PR DESCRIPTION
Story details: https://app.clubhouse.io/dashhudson/story/45296

`should set error when ldClient emits an error` is the only test that actually changed.

I think that, given we cannot assume that the failure value should always be false, it should be up to the developer to determine how to react in each situation.