### PR TITLE
Allow engines versions later than fixed value

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,8 +80,8 @@
     }
   },
   "engines": {
-    "node": "16.10",
-    "npm": "8.3.1"
+    "node": ">=16.10",
+    "npm": ">=8.3.1"
   },
   "sideEffects": false
 }


### PR DESCRIPTION
The values are fixed versions and thus will cause warnings/errors on _any_ version that isn't an exact match.

![image](https://user-images.githubusercontent.com/975824/201638470-0c7ea342-f6b2-456f-94d1-78d3e5010018.png)
